### PR TITLE
fix(peer-deps): update peerDep @commitlint/cli from 7.0.x to 7.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,6 @@
     "standard-version": "~4.4.0"
   },
   "peerDependencies": {
-    "@commitlint/cli": "~7.0.0"
+    "@commitlint/cli": "^7.0.0"
   }
 }


### PR DESCRIPTION
I am using `@commitlint/cli@7.2.1` and getting this error when installing with npm/yarn:
warning " > commitlint-config-cz@0.11.0" has incorrect peer dependency "@commitlint/cli@~7.0.0".

`~7.0.0` mean `7.0.x` while `^7.0.0` mean `7.x.x`

Thanks!